### PR TITLE
Add basic n8n node generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+generated

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# Automated-n8n-Custom-Node-Creation
+# Automated n8n Custom Node Creation
+
+This project provides a simple CLI tool that generates a minimal n8n community node from an OpenAPI specification. The goal is to automate boilerplate creation so you can quickly publish or install custom nodes.
+
+## Usage
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Run the generator with an OpenAPI JSON file:
+
+```bash
+node src/generate.js path/to/openapi.json
+```
+
+The script reads the first path and method from the specification and produces a TypeScript node under the `generated/` folder.
+
+3. Compile and publish the node following [n8n's guide](https://docs.n8n.io/hosting/custom-nodes/create-community-nodes/). After publishing to npm, the package can be installed on any n8n instance.
+
+## Example
+
+```
+node src/generate.js example-spec.json
+```
+
+This creates `generated/ExampleOperation.node.ts` which you can integrate into an n8n community package.
+
+## License
+
+MIT

--- a/example-spec.json
+++ b/example-spec.json
@@ -1,0 +1,19 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Example API",
+    "version": "1.0"
+  },
+  "paths": {
+    "/hello": {
+      "get": {
+        "operationId": "helloWorld",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,90 @@
+{
+  "name": "automated-n8n-custom-node-creation",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "automated-n8n-custom-node-creation",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@types/node": "^22.15.30",
+        "fs-extra": "^11.3.0",
+        "mustache": "^4.2.0",
+        "openapi-types": "^12.1.3"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "automated-n8n-custom-node-creation",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@types/node": "^22.15.30",
+    "fs-extra": "^11.3.0",
+    "mustache": "^4.2.0",
+    "openapi-types": "^12.1.3"
+  }
+}

--- a/src/generate.js
+++ b/src/generate.js
@@ -1,0 +1,32 @@
+const fs = require('fs-extra');
+const Mustache = require('mustache');
+
+async function main() {
+  const specPath = process.argv[2];
+  if (!specPath) {
+    console.error('Usage: node src/generate.js <openapi.json>');
+    process.exit(1);
+  }
+  const spec = await fs.readJson(specPath);
+  const pathEntry = Object.entries(spec.paths)[0];
+  if (!pathEntry) {
+    console.error('No paths found in spec');
+    process.exit(1);
+  }
+  const [path, methods] = pathEntry;
+  const methodEntry = Object.entries(methods)[0];
+  if (!methodEntry) {
+    console.error('No methods found for path');
+    process.exit(1);
+  }
+  const [method, operation] = methodEntry;
+  const nodeName = (operation.operationId || 'CustomNode').replace(/\s+/g, '');
+
+  const template = await fs.readFile('src/templates/node.mustache', 'utf8');
+  const rendered = Mustache.render(template, { nodeName, method: method.toUpperCase(), path });
+
+  await fs.outputFile(`generated/${nodeName}.node.ts`, rendered);
+  console.log(`Node generated: generated/${nodeName}.node.ts`);
+}
+
+main();

--- a/src/templates/node.mustache
+++ b/src/templates/node.mustache
@@ -1,0 +1,27 @@
+import { IExecuteFunctions } from "n8n-core";
+import { INodeExecutionData, INodeType, INodeTypeDescription } from "n8n-workflow";
+
+export class {{nodeName}} implements INodeType {
+    description: INodeTypeDescription = {
+        displayName: "{{nodeName}}",
+        name: "{{nodeName}}",
+        group: ['transform'],
+        version: 1,
+        description: 'Auto-generated node',
+        defaults: {
+            name: "{{nodeName}}",
+        },
+        inputs: ['main'],
+        outputs: ['main'],
+        credentials: [],
+        properties: [],
+    };
+
+    async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+        const response = await this.helpers.request({
+            method: '{{method}}',
+            url: `{{{path}}}`,
+        });
+        return [this.helpers.returnJsonArray(response)];
+    }
+}


### PR DESCRIPTION
## Summary
- create README with instructions
- add a simple generator tool that reads an OpenAPI file and outputs a node
- provide template for generated node
- include example OpenAPI spec

## Testing
- `node src/generate.js example-spec.json`

------
https://chatgpt.com/codex/tasks/task_b_684756535b9c832eabd77d9177de044a